### PR TITLE
Fix Back sometimes showing loading

### DIFF
--- a/alloc/alloc.c
+++ b/alloc/alloc.c
@@ -12,10 +12,20 @@ static uint32_t callback_exit_app(void *context)
     return VIEW_NONE; // Return VIEW_NONE to exit the app
 }
 
+void *global_app;
+void flip_world_show_submenu()
+{
+    FlipWorldApp *app = (FlipWorldApp *)global_app;
+    if (app->submenu) {
+        view_dispatcher_switch_to_view(app->view_dispatcher, FlipWorldViewSubmenu);
+    }
+}
+
 // Function to allocate resources for the FlipWorldApp
 FlipWorldApp *flip_world_app_alloc()
 {
     FlipWorldApp *app = (FlipWorldApp *)malloc(sizeof(FlipWorldApp));
+    global_app = app;
 
     Gui *gui = furi_record_open(RECORD_GUI);
 
@@ -42,7 +52,7 @@ FlipWorldApp *flip_world_app_alloc()
         return NULL;
     }
     submenu_add_item(app->submenu, "Play", FlipWorldSubmenuIndexRun, callback_submenu_choices, app);
-    submenu_add_item(app->submenu, "About", FlipWorldSubmenuIndexAbout, callback_submenu_choices, app);
+    submenu_add_item(app->submenu, "About", FlipWorldSubmenuIndexMessage, callback_submenu_choices, app);
     submenu_add_item(app->submenu, "Settings", FlipWorldSubmenuIndexSettings, callback_submenu_choices, app);
     //
 
@@ -91,6 +101,5 @@ void flip_world_app_free(FlipWorldApp *app)
     furi_record_close(RECORD_GUI);
 
     // free the app
-    if (app)
-        free(app);
+    if (app) free(app);
 }

--- a/alloc/alloc.h
+++ b/alloc/alloc.h
@@ -3,3 +3,4 @@
 
 FlipWorldApp *flip_world_app_alloc();
 void flip_world_app_free(FlipWorldApp *app);
+void flip_world_show_submenu();

--- a/callback/callback.h
+++ b/callback/callback.h
@@ -18,6 +18,18 @@ enum DataState
     DataStateError,
 };
 
+typedef enum MessageState MessageState;
+enum MessageState
+{
+    MessageStateAbout,
+    MessageStateLoading,
+};
+typedef struct MessageModel MessageModel;
+struct MessageModel
+{
+    MessageState message_state;
+};
+
 typedef struct DataLoaderModel DataLoaderModel;
 typedef bool (*DataLoaderFetch)(DataLoaderModel *model);
 typedef char *(*DataLoaderParser)(DataLoaderModel *model);

--- a/flip_world.h
+++ b/flip_world.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <font/font.h>
-#include <flipper_http/flipper_http.h>
 #include <easy_flipper/easy_flipper.h>
+#include <flipper_http/flipper_http.h>
+#include <font/font.h>
 
 // added by Derek Jamison to lower memory usage
 #undef FURI_LOG_E
@@ -14,15 +14,15 @@
 #define FURI_LOG_D(tag, msg, ...)
 //
 
-#define TAG "FlipWorld"
-#define VERSION 0.5
+#define TAG         "FlipWorld"
+#define VERSION     0.5
 #define VERSION_TAG TAG " " FAP_VERSION
 
 // Define the submenu items for our FlipWorld application
 typedef enum
 {
     FlipWorldSubmenuIndexRun, // Click to run the FlipWorld application
-    FlipWorldSubmenuIndexAbout,
+    FlipWorldSubmenuIndexMessage,
     FlipWorldSubmenuIndexSettings,
     FlipWorldSubmenuIndexWiFiSettings,
     FlipWorldSubmenuIndexGameSettings,
@@ -33,7 +33,7 @@ typedef enum
 typedef enum
 {
     FlipWorldViewSubmenu,          // The submenu
-    FlipWorldViewAbout,            // The about screen
+    FlipWorldViewMessage,          // The about, loading screen
     FlipWorldViewSettings,         // The settings screen
     FlipWorldViewVariableItemList, // The variable item list screen
     FlipWorldViewTextInput,        // The text input screen
@@ -56,7 +56,7 @@ typedef struct
     Widget *widget_result;
     //
     ViewDispatcher *view_dispatcher;       // Switches between our views
-    View *view_about;                      // The about screen
+    View *view_message;                    // The about, loading screen
     Submenu *submenu;                      // The submenu
     Submenu *submenu_settings;             // The settings submenu
     VariableItemList *variable_item_list;  // The variable item list (settngs)

--- a/game/game.c
+++ b/game/game.c
@@ -1,6 +1,7 @@
 #include <gui/view_holder.h>
 #include <game/game.h>
 #include <game/storage.h>
+#include <alloc/alloc.h>
 
 /****** Game ******/
 /*
@@ -53,6 +54,16 @@ static void game_start(GameManager *game_manager, void *ctx)
     game_context->imu_present = imu_present(game_context->imu);
 }
 
+static void thanks(Canvas *canvas, void *context)
+{
+    UNUSED(context);
+    canvas_set_font(canvas, FontPrimary);
+    canvas_draw_str(canvas, 35, 8, "Saving game");
+    canvas_set_font(canvas, FontSecondary);
+    canvas_draw_str(canvas, 0, 50, "Please wait while your");
+    canvas_draw_str(canvas, 0, 60, "game is saved.");
+}
+
 /*
     Write here the stop code for your game, for example, freeing memory, if it was allocated.
     You don't need to free level, sprites or entities, it will be done automatically.
@@ -68,32 +79,35 @@ static void game_stop(void *ctx)
     if (game_context->player_context)
     {
         if (!game_context->ended_early)
-            easy_flipper_dialog("Game Over", "Thanks for playing FlipWorld!\nHit BACK then wait for\nthe game to save.");
+            easy_flipper_dialog(
+                "Game Over",
+                "Thanks for playing FlipWorld!\nHit BACK then wait for\nthe game to save.");
         else
-            easy_flipper_dialog("Game Over", "Ran out of memory so the\ngame ended early.\nHit BACK to exit.");
+            easy_flipper_dialog(
+                "Game Over", "Ran out of memory so the\ngame ended early.\nHit BACK to exit.");
 
-        TextBox* text_box = text_box_alloc();
-        text_box_set_text(
-            text_box, "Thanks for playing!\n\nPlease wait while your\n game is saved.");
-        ViewHolder* view_holder = view_holder_alloc();
-        Gui* gui = furi_record_open(RECORD_GUI);
-        view_holder_attach_to_gui(view_holder, gui);
-        view_holder_set_view(view_holder, text_box_get_view(text_box));
+        ViewPort *view_port = view_port_alloc();
+        view_port_draw_callback_set(view_port, thanks, NULL);
+        Gui *gui = furi_record_open(RECORD_GUI);
+        gui_add_view_port(gui, view_port, GuiLayerFullscreen);
         uint32_t tick_count = furi_get_tick();
+        furi_delay_ms(800);
 
         save_player_context_api(game_context->player_context);
 
-        const uint32_t delay = 3000;
+        const uint32_t delay = 2500;
         tick_count = (tick_count + delay) - furi_get_tick();
-        if(tick_count < delay) {
+        if (tick_count <= delay)
+        {
             furi_delay_ms(tick_count);
         }
-        view_holder_set_view(view_holder, NULL);
-        view_holder_free(view_holder);
-        text_box_free(text_box);
-        furi_record_close(RECORD_GUI);
 
         easy_flipper_dialog("Game Saved", "Hit BACK to exit.");
+
+        flip_world_show_submenu();
+
+        gui_remove_view_port(gui, view_port);
+        furi_record_close(RECORD_GUI);
     }
 }
 
@@ -102,10 +116,10 @@ static void game_stop(void *ctx)
 */
 
 const Game game = {
-    .target_fps = 0,                     // set to 0 because we set this in game_app (callback.c line 22)
-    .show_fps = false,                   // show fps counter on the screen
-    .always_backlight = true,            // keep display backlight always on
-    .start = game_start,                 // will be called once, when game starts
-    .stop = game_stop,                   // will be called once, when game stops
+    .target_fps = 0,          // set to 0 because we set this in game_app (callback.c line 22)
+    .show_fps = false,        // show fps counter on the screen
+    .always_backlight = true, // keep display backlight always on
+    .start = game_start,      // will be called once, when game starts
+    .stop = game_stop,        // will be called once, when game stops
     .context_size = sizeof(GameContext), // size of game context
 };


### PR DESCRIPTION
Change `view_about` to a `view_message`; so we can show either "about" or "loading" screen using the same view.
Our "loading" view ignores all keyboard input (and is running in the background during game play). 

When the game ends, we use new `flip_world_show_submenu` method to switch the view_dispatcher back to the submenu.


We are currently allocating a new viewport for showing the "Saving game" message. In a future version, this view and the two dialogs that say "Game Over" and "Game Saved" could be moved to use the message view that was introduced.

NOTE: during the actual saving, `save_player_context_api`, we still sometimes run out of memory.